### PR TITLE
サイト名をappからwebに変更する

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,0 @@
-FROM nginx:1.10.1-alpine
-
-COPY fastly-app.namiking.net.conf /etc/nginx/conf.d
-EXPOSE 80 443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '2'
 services:
-  app:
-    build: app
+  web:
+    build: web
     environment:
-      - VIRTUAL_HOST=fastly-app.namiking.net
+      - VIRTUAL_HOST=fastly-web.namiking.net
   static:
     build: static
     volumes:
@@ -17,5 +17,5 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     depends_on:
-      - app
+      - web
       - static

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.10.1-alpine
+
+COPY fastly-web.namiking.net.conf /etc/nginx/conf.d
+EXPOSE 80 443

--- a/web/fastly-web.namiking.net.conf
+++ b/web/fastly-web.namiking.net.conf
@@ -1,9 +1,9 @@
 server {
     listen      80;
-    server_name fastly-app.namiking.net;
+    server_name fastly-web.namiking.net;
 
-    access_log  /var/log/nginx/fastly-app.namiking.net.access.log main;
-    error_log   /var/log/nginx/fastly-app.namiking.net.error.log info;
+    access_log  /var/log/nginx/fastly-web.namiking.net.access.log main;
+    error_log   /var/log/nginx/fastly-web.namiking.net.error.log info;
 
     location / {
         root    /usr/share/nginx/html;


### PR DESCRIPTION
後に`bin`ディレクトリを作ることになった時、並び順が、

```
app
bin
static
```

で、サイト名の間に挟まれるのが、微妙に嫌なため。
