### PR TITLE
nginx-proxyのポートを80から1234に変更する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   proxy:
     image: jwilder/nginx-proxy
     ports:
-      - '80:80'
+      - '1234:80'
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     depends_on:


### PR DESCRIPTION
テスト的なウェブアプリが80を使うとは片腹痛いので。
